### PR TITLE
guigui: add RunOptions.SetWindowFloating

### DIFF
--- a/app.go
+++ b/app.go
@@ -98,11 +98,12 @@ type app struct {
 var theApp app
 
 type RunOptions struct {
-	Title         string
-	WindowSize    image.Point
-	WindowMinSize image.Point
-	WindowMaxSize image.Point
-	AppScale      float64
+	Title             string
+	WindowSize        image.Point
+	WindowMinSize     image.Point
+	WindowMaxSize     image.Point
+	AppScale          float64
+	SetWindowFloating bool
 
 	RunGameOptions *ebiten.RunGameOptions
 }
@@ -139,6 +140,9 @@ func RunWithCustomFunc(root Widget, options *RunOptions, f func(game ebiten.Game
 		maxH = options.WindowMaxSize.Y
 	}
 	ebiten.SetWindowSizeLimits(minW, minH, maxW, maxH)
+	if options.SetWindowFloating {
+		ebiten.SetWindowFloating(true)
+	}
 
 	a := &theApp
 	a.root = root


### PR DESCRIPTION
Nice to meet you. 

## Overview

While using guigui, I needed a window that always stays on top. Fortunately, ebiten had a corresponding `SetWindowFloating()` function, so I repurposed it. 

I believe there is significant demand for windows to always stay on top in certain GUI applications, so I think it's a good idea for this to be treated as a general option for guigui.

## Message

If you believe this change is problematic, should be written differently, or is unnecessary because it should be placed directly in RunGameOptions, please feel free to close it.

Thank you for the wonderful library.