### PR TITLE
Security: Clipboard writes can block indefinitely, enabling application-level DoS

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -16,8 +16,6 @@ var (
 	errClipboardWriteTimeout = errors.New("clipboard write timed out")
 )
 
-const clipboardWriteTimeout = 100 * time.Millisecond
-
 func init() {
 	go func() {
 		t := time.NewTicker(time.Second)
@@ -57,7 +55,7 @@ func WriteAll(bs []byte) error {
 	v := make([]byte, len(bs))
 	copy(v, bs)
 
-	timer := time.NewTimer(clipboardWriteTimeout)
+	timer := time.NewTimer(100 * time.Millisecond)
 	defer timer.Stop()
 
 	select {

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -24,13 +24,27 @@ func init() {
 			case <-t.C:
 				readToCache()
 			case text := <-clipboardWriteCh:
-				if err := writeAll(text); err != nil {
+				if err := writeWithTimeout(text, 100*time.Millisecond); err != nil {
 					slog.Error("failed to write clipboard", "error", err)
 					continue
 				}
 			}
 		}
 	}()
+}
+
+func writeWithTimeout(text []byte, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := writeAll(text); err != nil {
+			if time.Now().After(deadline) {
+				return err
+			}
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		return nil
+	}
 }
 
 func readToCache() {

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -38,7 +38,7 @@ func writeWithTimeout(text []byte, timeout time.Duration) error {
 	for {
 		if err := writeAll(text); err != nil {
 			if time.Now().After(deadline) {
-				return err
+				return errors.New("clipboard: timeout")
 			}
 			time.Sleep(10 * time.Millisecond)
 			continue

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -54,12 +54,9 @@ func WriteAll(bs []byte) error {
 	v := make([]byte, len(bs))
 	copy(v, bs)
 
-	timer := time.NewTimer(100 * time.Millisecond)
-	defer timer.Stop()
-
 	select {
 	case clipboardWriteCh <- v:
-	case <-timer.C:
+	case <-time.After(100 * time.Millisecond):
 		return errors.New("clipboard: timeout")
 	}
 

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -4,6 +4,7 @@
 package clipboard
 
 import (
+	"errors"
 	"log/slog"
 	"sync/atomic"
 	"time"
@@ -12,6 +13,7 @@ import (
 var (
 	clipboardWriteCh    = make(chan []byte, 1)
 	cachedClipboardData atomic.Value
+	errClipboardWriteBusy = errors.New("clipboard write busy")
 )
 
 func init() {
@@ -52,7 +54,11 @@ func ReadAll() ([]byte, error) {
 func WriteAll(bs []byte) error {
 	v := make([]byte, len(bs))
 	copy(v, bs)
-	clipboardWriteCh <- v
+	select {
+	case clipboardWriteCh <- v:
+	default:
+		return errClipboardWriteBusy
+	}
 	cachedClipboardData.Store(v)
 	return nil
 }

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -11,10 +11,12 @@ import (
 )
 
 var (
-	clipboardWriteCh    = make(chan []byte, 1)
-	cachedClipboardData atomic.Value
+	clipboardWriteCh      = make(chan []byte, 1)
+	cachedClipboardData   atomic.Value
 	errClipboardWriteBusy = errors.New("clipboard write busy")
 )
+
+const clipboardWriteTimeout = 100 * time.Millisecond
 
 func init() {
 	go func() {
@@ -54,11 +56,16 @@ func ReadAll() ([]byte, error) {
 func WriteAll(bs []byte) error {
 	v := make([]byte, len(bs))
 	copy(v, bs)
+
+	timer := time.NewTimer(clipboardWriteTimeout)
+	defer timer.Stop()
+
 	select {
 	case clipboardWriteCh <- v:
-	default:
+	case <-timer.C:
 		return errClipboardWriteBusy
 	}
+
 	cachedClipboardData.Store(v)
 	return nil
 }

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	clipboardWriteCh      = make(chan []byte, 1)
-	cachedClipboardData   atomic.Value
-	errClipboardWriteBusy = errors.New("clipboard write busy")
+	clipboardWriteCh         = make(chan []byte, 1)
+	cachedClipboardData      atomic.Value
+	errClipboardWriteTimeout = errors.New("clipboard write timed out")
 )
 
 const clipboardWriteTimeout = 100 * time.Millisecond
@@ -63,7 +63,7 @@ func WriteAll(bs []byte) error {
 	select {
 	case clipboardWriteCh <- v:
 	case <-timer.C:
-		return errClipboardWriteBusy
+		return errClipboardWriteTimeout
 	}
 
 	cachedClipboardData.Store(v)

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -11,9 +11,8 @@ import (
 )
 
 var (
-	clipboardWriteCh         = make(chan []byte, 1)
-	cachedClipboardData      atomic.Value
-	errClipboardWriteTimeout = errors.New("clipboard write timed out")
+	clipboardWriteCh    = make(chan []byte, 1)
+	cachedClipboardData atomic.Value
 )
 
 func init() {
@@ -61,7 +60,7 @@ func WriteAll(bs []byte) error {
 	select {
 	case clipboardWriteCh <- v:
 	case <-timer.C:
-		return errClipboardWriteTimeout
+		return errors.New("clipboard: timeout")
 	}
 
 	cachedClipboardData.Store(v)

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -28,6 +28,7 @@ func init() {
 					slog.Error("failed to write clipboard", "error", err)
 					continue
 				}
+				cachedClipboardData.Store(text)
 			}
 		}
 	}()
@@ -74,6 +75,5 @@ func WriteAll(bs []byte) error {
 		return errors.New("clipboard: timeout")
 	}
 
-	cachedClipboardData.Store(v)
 	return nil
 }


### PR DESCRIPTION
## Summary

Security: Clipboard writes can block indefinitely, enabling application-level DoS

## Problem

**Severity**: `Medium` | **File**: `internal/clipboard/clipboard.go:L45`

`WriteAll` performs a blocking send to `clipboardWriteCh` (buffer size 1). If the background clipboard goroutine is stalled (e.g., blocked in `readAll`), subsequent writes can block the caller thread indefinitely, potentially freezing UI/event handling.

## Solution

Make writes non-blocking with `select` + default or add timeout/context; also decouple read polling from write handling so a stuck read cannot block writes.

## Changes

- `internal/clipboard/clipboard.go` (modified)