### PR TITLE
chore: remove completed TODO on ChildAdder.AddWidget

### DIFF
--- a/childadder.go
+++ b/childadder.go
@@ -8,7 +8,6 @@ type ChildAdder struct {
 	widget Widget
 }
 
-// TODO: Rename this to AddWidget.
 func (c *ChildAdder) AddWidget(widget Widget) {
 	widget.copyCheck()
 	widgetState := widget.widgetState()


### PR DESCRIPTION
The method is already named AddWidget, so the rename TODO is obsolete.