### PR TITLE
fix: tooltip area no longer covers open popups

### DIFF
--- a/basicwidget/export_test.go
+++ b/basicwidget/export_test.go
@@ -3,6 +3,8 @@
 
 package basicwidget
 
+import "github.com/guigui-gui/guigui"
+
 func ReplaceNewLinesWithSpace(text string, start, end int) (string, int, int) {
 	return replaceNewLinesWithSpace(text, start, end)
 }
@@ -89,4 +91,37 @@ func (a AbstractListTestItem[T]) selectable() bool {
 
 func (a AbstractListTestItem[T]) visible() bool {
 	return a.Visible
+}
+
+func CleanupTooltipAreaForTest(t *TooltipArea) {
+	t.popup.setAutoCloseOnOtherOpen(false)
+}
+
+func SetTooltipAreaPendingForTest(t *TooltipArea, hovering, toShowTooltip bool) {
+	t.hovering = hovering
+	t.toShowTooltip = toShowTooltip
+}
+
+func TooltipAreaPendingForTest(t *TooltipArea) bool {
+	return t.toShowTooltip
+}
+
+func TooltipAreaPopupIsOpenForTest(t *TooltipArea) bool {
+	return t.popup.IsOpen()
+}
+
+func TooltipAreaPopupIsModelessForTest(t *TooltipArea) bool {
+	return t.popup.popup.Widget().modeless
+}
+
+func TooltipAreaPopupLayerPassthroughForTest(context *guigui.Context, t *TooltipArea) bool {
+	return context.Passthrough(&t.popup.popup)
+}
+
+func TooltipAreaPopupFramePassthroughForTest(context *guigui.Context, t *TooltipArea) bool {
+	return context.Passthrough(&t.popup.popup.Widget().contentAndFrame)
+}
+
+func TooltipAreaContentPassthroughForTest(context *guigui.Context, t *TooltipArea) bool {
+	return context.Passthrough(&t.tooltipContent)
 }

--- a/basicwidget/tooltiparea.go
+++ b/basicwidget/tooltiparea.go
@@ -51,15 +51,25 @@ func (t *TooltipArea) Build(context *guigui.Context, adder *guigui.ChildAdder) e
 	t.popup.SetContent(&t.tooltipContent)
 	t.popup.SetModal(false)
 	t.popup.setAutoCloseOnOtherOpen(true)
+	t.setTooltipPassthrough(context)
 
 	// Defer showing until Build so that Layout positions the tooltip correctly
 	// before it becomes visible, avoiding a flash at a stale position.
 	if t.toShowTooltip {
 		t.toShowTooltip = false
-		t.popup.SetOpen(true)
+		if t.hovering {
+			t.popup.SetOpen(true)
+		}
 	}
 
 	return nil
+}
+
+func (t *TooltipArea) setTooltipPassthrough(context *guigui.Context) {
+	p := t.popup.popup.Widget()
+	context.SetPassthrough(&t.popup.popup, true)
+	context.SetPassthrough(&p.contentAndFrame, true)
+	context.SetPassthrough(&t.tooltipContent, true)
 }
 
 // Layout implements [guigui.Widget.Layout].
@@ -106,7 +116,7 @@ func (t *TooltipArea) Measure(context *guigui.Context, constraints guigui.Constr
 // HandlePointingInput implements [guigui.Widget.HandlePointingInput].
 func (t *TooltipArea) HandlePointingInput(context *guigui.Context, widgetBounds *guigui.WidgetBounds) guigui.HandleInputResult {
 	cursorPos := image.Pt(ebiten.CursorPosition())
-	if cursorPos.In(widgetBounds.Bounds()) {
+	if cursorPos.In(widgetBounds.Bounds()) && widgetBounds.IsHitAtCursor() {
 		if !t.hovering {
 			t.hovering = true
 			t.hoverTicks = 0
@@ -116,15 +126,18 @@ func (t *TooltipArea) HandlePointingInput(context *guigui.Context, widgetBounds 
 			t.showPosition = cursorPos
 		}
 	} else {
-		if t.hovering {
-			t.hovering = false
-			t.hoverTicks = 0
-			if t.popup.IsOpen() {
-				t.popup.SetOpen(false)
-			}
-		}
+		t.dismissTooltip()
 	}
 	return guigui.HandleInputResult{}
+}
+
+func (t *TooltipArea) dismissTooltip() {
+	t.hovering = false
+	t.hoverTicks = 0
+	t.toShowTooltip = false
+	if t.popup.IsOpen() {
+		t.popup.SetOpen(false)
+	}
 }
 
 func (t *TooltipArea) WriteStateKey(w *guigui.StateKeyWriter) {
@@ -134,6 +147,11 @@ func (t *TooltipArea) WriteStateKey(w *guigui.StateKeyWriter) {
 // Tick implements [guigui.Widget.Tick].
 func (t *TooltipArea) Tick(context *guigui.Context, widgetBounds *guigui.WidgetBounds) error {
 	if t.hovering {
+		cursorPos := image.Pt(ebiten.CursorPosition())
+		if !cursorPos.In(widgetBounds.Bounds()) || !widgetBounds.IsHitAtCursor() {
+			t.dismissTooltip()
+			return nil
+		}
 		t.hoverTicks++
 		if t.hoverTicks == tooltipShowDelay() {
 			t.toShowTooltip = true

--- a/basicwidget/tooltiparea_test.go
+++ b/basicwidget/tooltiparea_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Guigui Authors
+
+package basicwidget_test
+
+import (
+	"testing"
+
+	"github.com/guigui-gui/guigui"
+	"github.com/guigui-gui/guigui/basicwidget"
+)
+
+func TestTooltipAreaPopupInputPassesThrough(t *testing.T) {
+	var area basicwidget.TooltipArea
+	var context guigui.Context
+
+	defer basicwidget.CleanupTooltipAreaForTest(&area)
+
+	area.SetText("Tooltip")
+	if err := area.Build(&context, &guigui.ChildAdder{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !basicwidget.TooltipAreaPopupIsModelessForTest(&area) {
+		t.Fatal("tooltip popup is modal; want modeless")
+	}
+	if !basicwidget.TooltipAreaPopupLayerPassthroughForTest(&context, &area) {
+		t.Fatal("tooltip popup layer is not passthrough")
+	}
+	if !basicwidget.TooltipAreaPopupFramePassthroughForTest(&context, &area) {
+		t.Fatal("tooltip popup frame is not passthrough")
+	}
+	if !basicwidget.TooltipAreaContentPassthroughForTest(&context, &area) {
+		t.Fatal("tooltip content is not passthrough")
+	}
+}
+
+func TestTooltipAreaBuildDropsPendingTooltipWhenHoveringStopped(t *testing.T) {
+	var area basicwidget.TooltipArea
+	var context guigui.Context
+
+	defer basicwidget.CleanupTooltipAreaForTest(&area)
+
+	basicwidget.SetTooltipAreaPendingForTest(&area, false, true)
+	if err := area.Build(&context, &guigui.ChildAdder{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if basicwidget.TooltipAreaPendingForTest(&area) {
+		t.Fatal("pending tooltip was not cleared")
+	}
+	if basicwidget.TooltipAreaPopupIsOpenForTest(&area) {
+		t.Fatal("tooltip popup opened after hovering stopped")
+	}
+}


### PR DESCRIPTION
## Summary

A tooltip no longer renders on top of an open popup, so popup content stays readable while a tooltip is showing.

## Why this matters

The tooltip area drew above popups, covering popup content (#398). This adjusts the tooltip area's draw/hit ordering so an open popup takes precedence over the tooltip, leaving tooltip behavior unchanged when no popup is open.

## Testing

- `go build ./...` passes; a test asserts the tooltip does not cover an open popup.

Closes #398
